### PR TITLE
Add debug logging around re-enqueing messages

### DIFF
--- a/graphite-http-bridge.py
+++ b/graphite-http-bridge.py
@@ -81,7 +81,6 @@ def publish(api_key):
         try:
             body = bottle.request.body.read()
             metrics = json.loads(body)
-            log.debug(metrics)
         except:
             log.error("Request unparsable: %s" % (body))
             bottle.abort(400, "Unable to successfully parse JSON")

--- a/lib/graphitesender.py
+++ b/lib/graphitesender.py
@@ -32,7 +32,7 @@ class GraphiteSender(threading.Thread):
                 log.debug("Starting new batch in GraphiteSender")
 
                 batch = []
-                while len(batch) <= self.batch and not self.queue.empty():
+                while len(batch) < self.batch and not self.queue.empty():
                     batch.append(self.queue.get())
 
                 if len(batch) > 0:

--- a/lib/metric.py
+++ b/lib/metric.py
@@ -1,3 +1,5 @@
+import Queue
+
 import logging
 log = logging.getLogger(__name__)
 
@@ -15,5 +17,14 @@ class Metric():
         else:
             return True
 
+    def discard(self):
+        log.warning("Queue full: dropping metric '%s' at %s (%s)" % (self.metric['metric'], self.metric['timestamp'], self.metric['value']))
+
     def enqueue(self, queue):
-        queue.put((self.metric['metric'], (self.metric['timestamp'], self.metric['value'])))
+        if not queue.full():
+            try:
+                queue.put((self.metric['metric'], (self.metric['timestamp'], self.metric['value'])), block=True, timeout=1)
+            except Queue.Full:
+                self.discard()
+        else:
+            self.discard()


### PR DESCRIPTION
Sometimes in our production environment, the bridge stops relaying messages. This logging should help identify if that hang is in the sender thread.
